### PR TITLE
Enhance PostgreSQL URL Parsing to Support Optional Database Names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ keywords = ["sqlx", "postgres", "database", "test"]
 anyhow = "1"
 csv = "1.3"
 itertools = "0.12"
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1.35", features = ["macros", "rt", "rt-multi-thread"] }
 uuid = { version = "1.6", features = ["v4"] }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -15,12 +15,12 @@ pub struct TestPg {
 }
 
 impl TestPg {
-    pub fn new<S>(server_url: String, migrations: S) -> Self
+    pub fn new<S>(database_url: String, migrations: S) -> Self
     where
         S: MigrationSource<'static> + Send + Sync + 'static,
     {
         let uuid = Uuid::new_v4();
-        let (server_url, dbname) = parse_postgres_url(&server_url);
+        let (server_url, dbname) = parse_postgres_url(&database_url);
         let dbname = match dbname {
             Some(db_name) => format!("{}_test_{}", db_name, uuid),
             None => format!("test_{}", uuid),
@@ -29,7 +29,6 @@ impl TestPg {
 
         let tdb = Self { server_url, dbname };
 
-        let server_url = tdb.server_url();
         let url = tdb.url();
 
         // create database dbname
@@ -37,9 +36,9 @@ impl TestPg {
             let rt = Runtime::new().unwrap();
             rt.block_on(async move {
                 // use server url to create database
-                let mut conn = PgConnection::connect(&server_url)
+                let mut conn = PgConnection::connect(&database_url)
                     .await
-                    .unwrap_or_else(|_| panic!("Error while connecting to {}", server_url));
+                    .unwrap_or_else(|_| panic!("Error while connecting to {}", database_url));
                 conn.execute(format!(r#"CREATE DATABASE "{dbname_cloned}""#).as_str())
                     .await
                     .unwrap();

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -145,7 +145,7 @@ fn parse_postgres_url(url: &str) -> (String, Option<String>) {
     let url_without_protocol = url.trim_start_matches("postgres://");
 
     let parts: Vec<&str> = url_without_protocol.split('/').collect();
-    let server_url = parts[0].to_string();
+    let server_url = format!("postgres://{}", parts[0]);
 
     let dbname = if parts.len() > 1 && !parts[1].is_empty() {
         Some(parts[1].to_string())
@@ -155,7 +155,6 @@ fn parse_postgres_url(url: &str) -> (String, Option<String>) {
 
     (server_url, dbname)
 }
-
 #[cfg(test)]
 mod tests {
     use std::env;
@@ -217,17 +216,17 @@ mod tests {
     use super::*;
     #[test]
     fn test_with_dbname() {
-        let url = "postgres://liufankai:1@localhost/pureya";
+        let url = "postgres://testuser:1@localhost/pureya";
         let (server_url, dbname) = parse_postgres_url(url);
-        assert_eq!(server_url, "liufankai:1@localhost");
+        assert_eq!(server_url, "postgres://testuser:1@localhost");
         assert_eq!(dbname, Some("pureya".to_string()));
     }
 
     #[test]
     fn test_without_dbname() {
-        let url = "postgres://liufankai:1@localhost";
+        let url = "postgres://testuser:1@localhost";
         let (server_url, dbname) = parse_postgres_url(url);
-        assert_eq!(server_url, "liufankai:1@localhost");
+        assert_eq!(server_url, "postgres://testuser:1@localhost");
         assert_eq!(dbname, None);
     }
 }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -109,14 +109,13 @@ impl TestPg {
 
 impl Drop for TestPg {
     fn drop(&mut self) {
-        let server_url = self.server_url();
+        let database_url = self.url();
         let dbname = self.dbname.clone();
         thread::spawn(move || {
             let rt = Runtime::new().unwrap();
             rt.block_on(async move {
-                    let mut conn = PgConnection::connect(&server_url).await
-                    .unwrap_or_else(|_| panic!("Error while connecting to {}", server_url))
-                    ;
+                    let mut conn = PgConnection::connect(&database_url).await
+                    .unwrap_or_else(|_| panic!("Error while connecting to {}", database_url));
                     // terminate existing connections
                     sqlx::query(&format!(r#"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND datname = '{dbname}'"#))
                     .execute( &mut conn)

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -109,7 +109,8 @@ impl TestPg {
 
 impl Drop for TestPg {
     fn drop(&mut self) {
-        let database_url = self.url();
+        let server_url = &self.server_url;
+        let database_url = format!("{server_url}/postgres");
         let dbname = self.dbname.clone();
         thread::spawn(move || {
             let rt = Runtime::new().unwrap();


### PR DESCRIPTION
the parse_postgresql_url function, designed to enhance the handling of PostgreSQL connection strings within our application. 
When using 
``` shell
postgres://postgres:postgres@localhost
```
to connect to the database, the default assumption is that the postgres database exists, so the connection works fine.
However, if you use 
``` shell
postgres:// user:123@localhost 
```
to connect to the database, the program will try to connect to the user database, which usually does not exist. So, we've added to the original logic that the program will also work when a connection url with the database name is passed in.
