### PR TITLE
remove hyphen in db name

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "ISC",
 ]
@@ -126,8 +127,8 @@ exceptions = [
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -31,7 +31,8 @@ impl TestMysql {
         let password = password.into();
 
         let uuid = Uuid::new_v4();
-        let dbname = format!("test_{}", uuid);
+        let simple = uuid.simple();
+        let dbname = format!("test_{}", simple);
         let dbname_cloned = dbname.clone();
 
         let tdb = Self {

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -20,7 +20,8 @@ impl TestPg {
         S: MigrationSource<'static> + Send + Sync + 'static,
     {
         let uuid = Uuid::new_v4();
-        let dbname = format!("test_{uuid}");
+        let simple = uuid.simple();
+        let dbname = format!("test_{}", simple);
         let dbname_cloned = dbname.clone();
 
         let tdb = Self { server_url, dbname };


### PR DESCRIPTION
This PR removes hyphen character in temporary test db name. The current format of test db name is:

```text
test_f9519bbe-385f-4000-bcc0-9bd9e5689a8b
```

When test fails, the test db is not deleted automatically. We must use below command to delete it:

```sql
# with double quotation marks
drop database “test_f9519bbe-385f-4000-bcc0-9bd9e5689a8b”;
```

With this PR, the format of db name becomes:

```text
test_f9519bbe385f4000bcc09bd9e5689a8b
```

Then we can use below command to delete it:

```sql
# without double quotation marks
drop database test_f9519bbe385f4000bcc09bd9e5689a8b;
```
