### PR TITLE
Fix Readme.md Code error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ fn some_awesom_test() {
     let tdb = TestPg::new(
             "postgres://postgres:postgres@localhost:5432".to_string(),
             std::path::Path::new("./migrations"),
-        )
+        );
     let pool = tdb.get_pool().await;
     // do something with the pool
 


### PR DESCRIPTION
There is a syntax error in the original Readme instance code.