### PR TITLE
chore: deps: bump to latest (cargo update/upgrade --compatible)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ anyhow = "1"
 csv = "1.4"
 itertools = "0.14"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls"] }
-tokio = { version = "1.48", features = ["macros", "rt", "rt-multi-thread"] }
-uuid = { version = "1.18", features = ["v4"] }
+tokio = { version = "1.52", features = ["macros", "rt", "rt-multi-thread"] }
+uuid = { version = "1.23", features = ["v4"] }


### PR DESCRIPTION
it'd be great if we could get a release that depends on sqlx 0.8 :)